### PR TITLE
Integrate uxkit-screenshare module #43

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,17 @@ buildscript {
 }
 
 def modules_sdk = [
-        'uxkit', 'uxkit-exoplayer-support', 'uxkit-firebase',
+        // main module
+        'uxkit',
+        // firebase support
+        'uxkit-firebase',
+        // in conference specific "presentation"
+        'uxkit-exoplayer-support', 'uxkit-youtube', 'uxkit-screenshare',
+        // plugins related to services and system info
         'uxkit-incoming-call', 'uxkit-self-managed-call', 'uxkit-system-service',
-        'uxkit-youtube', 'uxkit-common'
+        // common module
+        'uxkit-common',
+
 ]
 
 ext {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 include ':app'
 include ':uxkit'
 include ':uxkit-youtube'
+include ':uxkit-screenshare'
 include ':uxkit-exoplayer-support'
 include ':uxkit-incoming-call'
 include ':uxkit-firebase'

--- a/uxkit-screenshare/build.gradle
+++ b/uxkit-screenshare/build.gradle
@@ -1,0 +1,59 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+
+    defaultConfig {
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        buildConfigField "String", "VERSION_NAME", "\"${rootProject.ext.voxeetUXKitVersion}\""
+    }
+
+    buildTypes {
+        release {
+            shrinkResources false
+            minifyEnabled false
+        }
+    }
+
+    allprojects {
+        tasks.withType(Javadoc) {
+            options.addStringOption('Xdoclint:none', '-quiet')
+            options.addStringOption('encoding', 'UTF-8')
+        }
+    }
+
+    packagingOptions {
+        exclude 'META-INF/DEPENDENCIES'
+        exclude 'META-INF/NOTICE'
+        exclude 'META-INF/LICENSE'
+    }
+
+    lintOptions {
+        abortOnError false
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+configurations {
+    javadocDeps
+}
+
+dependencies {
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    })
+    api project(":uxkit")
+    api project(":uxkit-common")
+}
+
+apply from: "../advanced_gradle/license.gradle"
+apply from: "../advanced_gradle/tasks.gradle"
+apply from: "../advanced_gradle/publishing.gradle"

--- a/uxkit-screenshare/src/main/AndroidManifest.xml
+++ b/uxkit-screenshare/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.voxeet.uxkit.screenshare">
+
+    <application
+        android:label="@string/app_name"
+        android:supportsRtl="true">
+        <provider
+            android:name="com.voxeet.uxkit.screenshare.manifests.ScreenShareMediaPresentationProviderManifestComponent"
+            android:authorities="${applicationId}.manifests.ScreenShareMediaPresentationProviderManifestComponent"
+            android:enabled="true"
+            android:exported="false" />
+    </application>
+
+</manifest>

--- a/uxkit-screenshare/src/main/java/com/voxeet/uxkit/screenshare/ScreenShareMediaPresentationProvider.java
+++ b/uxkit-screenshare/src/main/java/com/voxeet/uxkit/screenshare/ScreenShareMediaPresentationProvider.java
@@ -1,0 +1,52 @@
+package com.voxeet.uxkit.screenshare;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.voxeet.uxkit.common.UXKitLogger;
+import com.voxeet.uxkit.common.logging.ShortLogger;
+import com.voxeet.uxkit.presentation.provider.AbstractMediaPlayerProvider;
+
+/**
+ * Manage and create screenshare videos
+ */
+public class ScreenShareMediaPresentationProvider extends AbstractMediaPlayerProvider<ScreenShareMediaPresentationView> {
+
+    private final static ShortLogger Log = UXKitLogger.createLogger(ScreenShareMediaPresentationProvider.class);
+
+    /**
+     * Default constructor
+     */
+    public ScreenShareMediaPresentationProvider() {
+    }
+
+    /**
+     * Method called to check if a given video can be used by this provider.
+     * To be compatible, developers needs to send an attempt with "screenshare://"
+     * <p>
+     * A way to inject those event is to create programmatically a VideoPresentationStartedEvent when a MediaStreamType.ScreenShare is detected
+     *
+     * @param url an url to be checked upon
+     * @return true if this provider can be used
+     */
+    @Override
+    public boolean isUrlCompatible(@NonNull String url) {
+        boolean compatible = url.startsWith("screenshare://");
+        Log.d("isUrlCompatible " + url + " " + compatible);
+        return compatible;
+    }
+
+    /**
+     * Creates an instance of the ScreenShareMediaPresentationView
+     *
+     * @param context a valid context to be linked upon
+     * @return the newly created instance
+     */
+    @NonNull
+    @Override
+    public ScreenShareMediaPresentationView createMediaPlayerView(@NonNull Context context) {
+        Log.d("createMediaPlayerView called");
+        return new ScreenShareMediaPresentationView(context);
+    }
+}

--- a/uxkit-screenshare/src/main/java/com/voxeet/uxkit/screenshare/ScreenShareMediaPresentationView.java
+++ b/uxkit-screenshare/src/main/java/com/voxeet/uxkit/screenshare/ScreenShareMediaPresentationView.java
@@ -1,0 +1,228 @@
+package com.voxeet.uxkit.screenshare;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.ScaleGestureDetector;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.voxeet.VoxeetSDK;
+import com.voxeet.android.media.MediaStream;
+import com.voxeet.android.media.stream.MediaStreamType;
+import com.voxeet.sdk.events.v2.StreamAddedEvent;
+import com.voxeet.sdk.events.v2.StreamRemovedEvent;
+import com.voxeet.sdk.events.v2.StreamUpdatedEvent;
+import com.voxeet.sdk.json.VideoPresentationPaused;
+import com.voxeet.sdk.json.VideoPresentationPlay;
+import com.voxeet.sdk.json.VideoPresentationSeek;
+import com.voxeet.sdk.json.VideoPresentationStarted;
+import com.voxeet.sdk.json.VideoPresentationStopped;
+import com.voxeet.sdk.models.Participant;
+import com.voxeet.sdk.utils.Map;
+import com.voxeet.sdk.views.VideoView;
+import com.voxeet.uxkit.common.UXKitLogger;
+import com.voxeet.uxkit.common.logging.ShortLogger;
+import com.voxeet.uxkit.presentation.view.AbstractMediaPlayerView;
+import com.voxeet.uxkit.screenshare.utils.PinchGestureProvider;
+
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+import org.webrtc.RendererCommon;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Simple implementation to help integrate screenshare playback into Apps
+ */
+public class ScreenShareMediaPresentationView extends AbstractMediaPlayerView {
+
+    private final static ShortLogger Log = UXKitLogger.createLogger(ScreenShareMediaPresentationView.class);
+    private final ScreenShareEvents events = new ScreenShareEvents();
+
+
+    @Nullable
+    private VideoView videoView;
+
+    @SuppressLint("ClickableViewAccessibility")
+    public ScreenShareMediaPresentationView(@NonNull Context context) {
+        super(context);
+
+        ScaleGestureDetector pinchDetector = PinchGestureProvider.create(context,
+                this::onVideoViewFill,
+                this::onVideoViewFit);
+
+        setOnTouchListener((view, event) -> pinchDetector.onTouchEvent(event));
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+
+        EventBus eventBus = EventBus.getDefault();
+        if (!eventBus.isRegistered(events)) eventBus.register(events);
+
+        // also maange the screenshare state from here
+        updateStreamToDisplay();
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        EventBus eventBus = EventBus.getDefault();
+        if (eventBus.isRegistered(events)) eventBus.unregister(events);
+
+        super.onDetachedFromWindow();
+    }
+
+    /**
+     * A video start has been requested with a specific key and information
+     *
+     * @param videoPresentationStarted valid information
+     */
+    @Override
+    public void start(@NonNull VideoPresentationStarted videoPresentationStarted) {
+        // not usefull here
+    }
+
+    /**
+     * A video has been stopped
+     *
+     * @param videoPresentationStopped a valid instance
+     */
+    @Override
+    public void stop(@NonNull VideoPresentationStopped videoPresentationStopped) {
+        // not usefull here
+    }
+
+    /**
+     * A video is playing/resuming
+     *
+     * @param videoPresentationPlay a valid instance
+     */
+    @Override
+    public void play(@NonNull VideoPresentationPlay videoPresentationPlay) {
+        // not usefull here
+    }
+
+    /**
+     * A video has been paused
+     *
+     * @param videoPresentationPaused a valid instance
+     */
+    @Override
+    public void pause(@NonNull VideoPresentationPaused videoPresentationPaused) {
+        // not usefull here
+    }
+
+    /**
+     * A video's timer has been changed to a specific position
+     *
+     * @param videoPresentationSeek a valid instance
+     */
+    @Override
+    public void seek(@NonNull VideoPresentationSeek videoPresentationSeek) {
+        // not usefull here
+    }
+
+    @Nullable
+    private VideoView getOrManageVideoView() {
+        if (null != videoView) return videoView;
+
+        View layout = LayoutInflater.from(getContext()).inflate(R.layout.uxkit_screenshare, this);
+
+        videoView = layout.findViewById(R.id.uxkit_screenshare_videoview);
+        return videoView;
+    }
+
+    private void updateStreamToDisplay() {
+        VideoView videoView = getOrManageVideoView();
+
+        if (null == videoView) {
+            Log.e("updateStreamToDisplay the videoView is invalid", new IllegalStateException("invalid videoView"));
+            return;
+        }
+
+        Runnable invalid_state = () -> {
+            videoView.setVisibility(View.GONE);
+            if (videoView.isAttached()) videoView.unAttach();
+        };
+
+        Participant withScreenShare = Map.find(VoxeetSDK.conference().getParticipants(),
+                participant -> {
+                    MediaStream stream = participant.streamsHandler().getFirst(MediaStreamType.ScreenShare);
+                    return null != stream && stream.videoTracks().size() > 0;
+                });
+
+        if (null == withScreenShare) {
+            invalid_state.run();
+            return;
+        }
+
+        MediaStream stream = Map.find(withScreenShare.streams(), mediaStream -> {
+            if (null == mediaStream) return false;
+            if (!MediaStreamType.ScreenShare.equals(mediaStream.getType())) return false;
+            return mediaStream.videoTracks().size() > 0;
+        });
+
+        if (null == stream) {
+            invalid_state.run();
+            return;
+        }
+
+        String peerId = videoView.getPeerId();
+        boolean isDifferent = null == peerId || !peerId.equals(withScreenShare.getId());
+        String participantId = withScreenShare.getId();
+
+        if (null == participantId) return;
+
+        if (View.VISIBLE != videoView.getVisibility()) {
+            videoView.setVisibility(View.VISIBLE);
+        }
+
+        if (!videoView.isAttached() || isDifferent) {
+            videoView.attach(withScreenShare.getId(), stream);
+        }
+    }
+
+    /**
+     * Change the VideoView to fill (the stream will fill the whole video space)
+     * Aspect ratio is conserved
+     */
+    private void onVideoViewFill() {
+        if (null == videoView) return;
+        videoView.setVideoFill();
+    }
+
+    /**
+     * Change the VideoView to fit (the stream will be modified to be fully seen in the view
+     * Aspect ratio is conserved
+     */
+    private void onVideoViewFit() {
+        if (null == videoView) return;
+        videoView.setVideoFit();
+    }
+
+    private final class ScreenShareEvents {
+
+        @Subscribe
+        public void onEvent(@NonNull StreamAddedEvent event) {
+            Log.d("ScreenShareEvents/StreamAddedEvent " + event);
+            updateStreamToDisplay();
+        }
+
+        @Subscribe
+        public void onEvent(@NonNull StreamUpdatedEvent event) {
+            Log.d("ScreenShareEvents/StreamUpdatedEvent " + event);
+            updateStreamToDisplay();
+        }
+
+        @Subscribe
+        public void onEvent(@NonNull StreamRemovedEvent event) {
+            Log.d("ScreenShareEvents/StreamRemovedEvent " + event);
+            updateStreamToDisplay();
+        }
+    }
+}

--- a/uxkit-screenshare/src/main/java/com/voxeet/uxkit/screenshare/manifests/ScreenShareMediaPresentationProviderManifestComponent.java
+++ b/uxkit-screenshare/src/main/java/com/voxeet/uxkit/screenshare/manifests/ScreenShareMediaPresentationProviderManifestComponent.java
@@ -1,0 +1,29 @@
+package com.voxeet.uxkit.screenshare.manifests;
+
+import android.content.Context;
+import android.content.pm.ProviderInfo;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.voxeet.sdk.manifests.AbstractManifestComponentProvider;
+import com.voxeet.uxkit.presentation.controller.MediaPlayerProviderController;
+import com.voxeet.uxkit.screenshare.ScreenShareMediaPresentationProvider;
+
+public final class ScreenShareMediaPresentationProviderManifestComponent extends AbstractManifestComponentProvider {
+
+    @Override
+    protected void init(@NonNull Context context, @Nullable ProviderInfo providerInfo) {
+        MediaPlayerProviderController.register(new ScreenShareMediaPresentationProvider());
+    }
+
+    @Override
+    protected String getComponentName() {
+        return ScreenShareMediaPresentationProviderManifestComponent.class.getSimpleName();
+    }
+
+    @Override
+    protected String getDefaultAuthority() {
+        return "com.voxeet.uxkit.screenshare.manifests.";
+    }
+}

--- a/uxkit-screenshare/src/main/java/com/voxeet/uxkit/screenshare/utils/PinchGestureProvider.java
+++ b/uxkit-screenshare/src/main/java/com/voxeet/uxkit/screenshare/utils/PinchGestureProvider.java
@@ -1,0 +1,64 @@
+package com.voxeet.uxkit.screenshare.utils;
+
+import android.content.Context;
+import android.view.ScaleGestureDetector;
+
+import androidx.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PinchGestureProvider {
+
+    private final static int MAXIMUM_SCALE_FACTORS = 5;
+
+    /**
+     * Create an instance of ScaleGestureDetector which will warn when a zoom/dezoom needs to be performed
+     *
+     * @param context  the context to use
+     * @param onZoom   callback for zooming
+     * @param onDezoom callback for dezoom
+     * @return a non null instance
+     */
+    @NonNull
+    public static ScaleGestureDetector create(@NonNull Context context,
+                                              @NonNull Runnable onZoom,
+                                              @NonNull Runnable onDezoom) {
+        return new ScaleGestureDetector(context, new ScaleGestureDetector.SimpleOnScaleGestureListener() {
+            List<Float> mItems = new ArrayList<>();
+
+            @Override
+            public boolean onScale(ScaleGestureDetector detector) {
+                float scaleFactor = detector.getScaleFactor();
+                while (mItems.size() > MAXIMUM_SCALE_FACTORS) mItems.remove(0);
+                mItems.add(scaleFactor);
+
+                return super.onScale(detector);
+            }
+
+            @Override
+            public boolean onScaleBegin(ScaleGestureDetector detector) {
+                mItems.clear();
+                return super.onScaleBegin(detector);
+            }
+
+            @Override
+            public void onScaleEnd(ScaleGestureDetector detector) {
+                int up = 0;
+                int down = 0;
+                for (int i = 0, j = 1; i < mItems.size() && j < mItems.size(); i++, j++) {
+                    if (mItems.get(i) < mItems.get(j)) up++;
+                    else down++;
+                }
+
+                if (up > down) {
+                    onZoom.run();
+                } else {
+                    onDezoom.run();
+                }
+
+                super.onScaleEnd(detector);
+            }
+        });
+    }
+}

--- a/uxkit-screenshare/src/main/res/layout/uxkit_screenshare.xml
+++ b/uxkit-screenshare/src/main/res/layout/uxkit_screenshare.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.voxeet.sdk.views.VideoView
+        android:id="@+id/uxkit_screenshare_videoview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:streamScaleType="scale_fill" />
+</FrameLayout>


### PR DESCRIPTION
Create a new optional module which helps integrating screen share injection into the default Presentation manager. To do so, VideoPresentationStarted and VideoPresentationStopped needs to be create manually for a "screenshare://" url and session

It doesn't replace custom screenshare management, it's only here as an optional mean to create an experience where all "presentations" are in one place