### PR TITLE
Update CodeQL and set expected maven math range for version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.

--- a/sdk.gradle
+++ b/sdk.gradle
@@ -2,4 +2,4 @@ def version_from_sdk = { String version ->  project.hasProperty("SDK_VERSION") &
         ? "${project.SDK_VERSION}"
         : version }
 
-rootProject.ext.voxeetSdkVersion = version_from_sdk("3.8.+")
+rootProject.ext.voxeetSdkVersion = version_from_sdk("[3.8.1,)")


### PR DESCRIPTION
Fixes CodeQL's version used & also Sonatype's expected maven pom definition for the dependencies and automatic patch versions used (set current one to 3.8.1+ as it was the first one to be mavenCentral()-friendly)